### PR TITLE
RenderFlex issue fix (overflowed by X pixels)

### DIFF
--- a/images_using_php_api/lib/main.dart
+++ b/images_using_php_api/lib/main.dart
@@ -124,7 +124,7 @@ class _HomePageState extends State<HomePage> {
           ),
           // ternary operator condition for image path whether choosen or not ---> if imagepath is not null then show image if null then show text
           imagePath != null
-              ? Image.file(imagePath!)
+              ? Expanded(child: Image.file(imagePath!))
               : const Text('Image not choosen yet !', style: TextStyle(fontSize: 20, color: Colors.purple),),
           const SizedBox(
             height: 20,


### PR DESCRIPTION
I was practicing creating mobile apps using Flutter and I was having an issue with images rendering (images_using_php_api) as they were extending beyond the phone screen. My solution is to use `Expanded(child: Image.file(imagePath!))` instead of `Image.file(imagePath!)` on 127 row